### PR TITLE
Discretized toolpaths and control updates

### DIFF
--- a/jun25_dwell_rook_toolpath/toolpath_writer.py
+++ b/jun25_dwell_rook_toolpath/toolpath_writer.py
@@ -3,6 +3,7 @@ import numpy as np
 import re
 import os
 import json
+import random
 from typing import List, Tuple
 
 def get_time_position_power_inp(file):
@@ -334,6 +335,71 @@ def write_toolpath(toolpath_info):
     tpp_clean, layer_end_times = create_toolpath(toolpath_info)
 
     write_event_series(tpp_clean, toolpath_info['scan_path_out'], toolpath_info['includes_end_message'])
+
+
+def generate_control_options(layer_time_discretization, num_forward_sims, sampling_strategy, toolpath_info):
+    
+    def get_uniform_random_discrete_value(bounds, discrete_step):
+        x = random.uniform(bounds[0], bounds[1])
+        out = round(x / discrete_step) * discrete_step
+        return out
+
+
+    dwell_0_bounds = (layer_time_discretization, 10*layer_time_discretization)
+    dwell_1_bounds = (layer_time_discretization, 10*layer_time_discretization)
+    reheat_power_bounds = (0.0, 500.0)
+
+    modified_toolpath_info_list = []
+
+    num_variables = 3
+    num_adjacent_options = 2 * num_variables + 1
+
+
+    match sampling_strategy:
+        case 'uniform_random':
+            for i in range(num_forward_sims):   
+                
+                unique_parameter_set_found = False
+                counter = 0
+
+                while not unique_parameter_set_found:
+                    # Draw new values
+                    dwell_0_val = get_uniform_random_discrete_value(dwell_0_bounds, layer_time_discretization)
+                    dwell_1_val = get_uniform_random_discrete_value(dwell_1_bounds, layer_time_discretization)
+                    reheat_val = get_uniform_random_discrete_value(reheat_power_bounds, 1.0)
+
+                    # Compare to existing values
+                    for entry in modified_toolpath_info_list:
+                        if np.isclose(dwell_0_val, entry['dwell_0']) and np.isclose(dwell_1_val, entry['dwell_1']) and np.isclose(reheat_val, entry['reheat_power']):
+                            counter = counter + 1
+                            if counter > 1000:
+                                print('Error: Unable to find enough unique random samples for the control simulations')
+                                sys.exit()
+                            continue
+                        
+                    modified_toolpath_info_list.append(copy.deepcopy(toolpath_info))
+                    modified_toolpath_info_list[-1]['dwell_0'] = dwell_0_val
+                    modified_toolpath_info_list[-1]['dwell_1'] = dwell_1_val
+                    modified_toolpath_info_list[-1]['reheat_power'] = reheat_val
+                    unique_parameter_set_found = True
+
+            return modified_toolpath_info_list
+        
+        case 'normal_random':
+            # TODO
+            return modified_toolpath_info_list
+
+        case 'individual_perturbations':
+            neighbors_to_sample_from = np.ceil(num_forward_sims/num_adjacent_options)
+            # TODO
+            return modified_toolpath_info_list
+        
+        case _:
+            print('Error: Invalid sampling strategy chosen:', sampling_strategy)
+            sys.exit()
+    
+    return modified_toolpath_info_list
+
 
 if __name__ == "__main__":
     """

--- a/jun25_dwell_rook_toolpath/toolpath_writer.py
+++ b/jun25_dwell_rook_toolpath/toolpath_writer.py
@@ -51,6 +51,7 @@ def extract_single_layer(time_position_power, target_layer):
 
 def write_event_series(time_position_power, filename, include_end_message):
     scan_path_string = ""
+    
     for entry in time_position_power:
         time = entry[0]
         if time > 1e-4:
@@ -175,7 +176,7 @@ def pick_chunk(values: List[float], layer_idx: int, num_layers: int) -> float:
     cidx = min(int(layer_idx // width), n_chunks - 1)
     return values[cidx]
   
-def get_toolpath_info(print_path, reheat_path, dwell_0, dwell_1, reheat_power):
+def get_toolpath_info(print_path, reheat_path, dwell_0, dwell_1, reheat_power, layer_end_time_discretization=None):
     toolpath_info = {}
     toolpath_info['print_path'] = print_path
     toolpath_info['reheat_path'] = reheat_path
@@ -185,6 +186,9 @@ def get_toolpath_info(print_path, reheat_path, dwell_0, dwell_1, reheat_power):
     toolpath_info['scan_path_out'] = "scan_path.inp"
     toolpath_info['lump_size'] = 2
     toolpath_info['includes_end_message'] = True
+    toolpath_info['layer_end_time_discretization'] = layer_end_time_discretization
+
+    toolpath_info['admissible_controls'] = ('reheat_power, dwell_0', 'dwell_1')
 
     filename_pattern = 'layer_(\d+)_scan_path\.txt'
     filenames_print = get_sorted_layer_files(print_path, filename_pattern)
@@ -272,6 +276,7 @@ def create_toolpath(toolpath_info):
     # 3) Build the new time–position–power series
     new_tpp = []
     section_start_time = 1e-10
+    layer_end_times = []
     for layer_idx in range(*toolpath_info['selected_layers']):
         # 3a) Pick parameters for this layer
         d0 = pick_chunk(dwell_0,      layer_idx, num_layers)
@@ -305,14 +310,28 @@ def create_toolpath(toolpath_info):
         pos  = new_tpp[-1][1]
         new_tpp += time_position_power_dwell(t_d1, pos, d1)
         section_start_time = new_tpp[-1][0]
+
+        # 3e) Add an additional dwell at the end of the layer to hit the discretized layer time
+        layer_end_time = new_tpp[-1][0]
+        if (toolpath_info['layer_end_time_discretization'] is not None):
+            remainder = layer_end_time % toolpath_info['layer_end_time_discretization']
+
+            additional_dwell_to_add = toolpath_info['layer_end_time_discretization'] - remainder
+
+            new_tpp += time_position_power_dwell(t_d1, pos, additional_dwell_to_add)
+            section_start_time = new_tpp[-1][0]
+            layer_end_time = new_tpp[-1][0]
+
+        layer_end_times.append(layer_end_time)
+
     # 4) Clean up and return
     tpp_clean = strip_duplicate_locations(new_tpp)
 
-    return tpp_clean
+    return tpp_clean, layer_end_times
 
 def write_toolpath(toolpath_info):
     
-    tpp_clean = create_toolpath(toolpath_info)
+    tpp_clean, layer_end_times = create_toolpath(toolpath_info)
 
     write_event_series(tpp_clean, toolpath_info['scan_path_out'], toolpath_info['includes_end_message'])
 

--- a/tests/test_jun25_dwell_rook_toolpath.py
+++ b/tests/test_jun25_dwell_rook_toolpath.py
@@ -5,8 +5,11 @@ import numpy as np
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from jun25_dwell_rook_toolpath.toolpath_writer import get_toolpath_info
+from jun25_dwell_rook_toolpath.toolpath_writer import create_toolpath
 from jun25_dwell_rook_toolpath.toolpath_writer import write_toolpath
 from jun25_dwell_rook_toolpath.toolpath_writer import generate_print_plan_file
+from jun25_dwell_rook_toolpath.toolpath_writer import write_event_series
+
 
 
 def write_full_toolpath():
@@ -60,7 +63,38 @@ def write_two_layer_toolpath():
 
     return passed
 
+def write_four_layer_discretized_toolpath():
+    print("Test: Four-layer discretized toolpath")
+
+    workflow_scripts_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    toolpath_generator_path = os.path.join(workflow_scripts_path, 'jun25_dwell_rook_toolpath')
+    print_path = os.path.join(toolpath_generator_path, 'print_layers')
+    reheat_path = os.path.join(toolpath_generator_path, 'reheat_layers')
+    dwell_0 = [10]
+    dwell_1 = [10]
+    reheat_power = [500]
+    
+    toolpath_info = get_toolpath_info(print_path, reheat_path, dwell_0, dwell_1, reheat_power, layer_end_time_discretization=12.0)
+    layer_thickness = toolpath_info['layer_height']
+    toolpath_info['selected_layers'] = [0, 4]
+    scan_path_filename = "scan_path_4_layer_discretized_test.inp"
+    template_scan_path_filename = scan_path_filename
+    toolpath_info['scan_path_out'] = template_scan_path_filename
+
+    tpp_clean, layer_end_times = create_toolpath(toolpath_info)
+    write_event_series(tpp_clean, toolpath_info['scan_path_out'], toolpath_info['includes_end_message'])    
+
+    passed = np.allclose(layer_end_times,[98, 242, 338])
+
+    if passed:
+        print("Test passed!")
+    else:
+        print("Test failed!")
+
+    return passed
+
 def write_print_plan():
+    print("Test: Write print plan")
 
     toolpath_info = {
         'dwell_0'       : [20, 30, 40, 50],
@@ -86,6 +120,8 @@ def main():
     write_full_toolpath()
 
     write_two_layer_toolpath()
+
+    write_four_layer_discretized_toolpath()
 
     write_print_plan()
     


### PR DESCRIPTION
This PR adds two new capabilities to the jun25_dwell_rook_toolpath module:
1) It adds the option to add extra dwells such that the layers all end with a specified discrete increment (e.g. layers always end in increments of 15 seconds)
2) It adds a new function to generate control options for adaptive control. This is necessary to keep the control driver agnostic to toolpath details. It currently has just random sampling and more need to be added.