### PR TITLE
Avoid changing scan path when stripping segments with duplicate positions

### DIFF
--- a/jun25_dwell_rook_toolpath/toolpath_writer.py
+++ b/jun25_dwell_rook_toolpath/toolpath_writer.py
@@ -122,7 +122,9 @@ def shift_time(layer, new_start_time, eps=1e-12):
     return new_layer
 
 def add_power_off_entry(layer, eps=1e-10):
-    new_layer = [(layer[0][0], layer[0][1], 0.0)]
+    # New layer initial dwell - slightly perturb x position to ensure unique value
+    new_layer_position = (layer[0][1][0] + eps, layer[0][1][1], layer[0][1][2])
+    new_layer = [(layer[0][0], new_layer_position, 0.0)]
     new_layer = new_layer + [(layer[0][0]+ eps, layer[0][1], layer[0][2])]
     new_layer = new_layer + layer[1:]
 
@@ -154,12 +156,26 @@ def flatten_layer_z(layer, reference_index=0):
 
     return new_layer
 
-def strip_duplicate_locations(time_position_power):
+def strip_duplicate_locations(time_position_power, eps=1e-10):
     out = []
     for entry in reversed(time_position_power):
         if len(out) > 0:
+            # Check whether this entry is at the same position as the one after it
             if entry[1] != out[-1][1]:
+                # This entry is at a new position - append this event
                 out.append(entry)
+            else:
+                # This entry is as the same position as the one after it
+                # If both entries are dwells, they can be combined
+                # Otherwise, combining entries will change the scan path itself
+                # To avoid this, slightly perturb the position rather than combining entries
+                # This is necessary as adamantine cannot handle consecutive entries with the same position
+                if entry[2] != 0 or out[-1][2] != 0:
+                    # Slightly perturb x position
+                    modified_position = (entry[1][0] + eps, entry[1][1], entry[1][2])
+                    modified_entry = (entry[0], modified_position, entry[2])
+                    # Append this modified event
+                    out.append(modified_entry)
         else:
             out.append(entry)
 

--- a/jun25_dwell_rook_toolpath/toolpath_writer.py
+++ b/jun25_dwell_rook_toolpath/toolpath_writer.py
@@ -165,7 +165,7 @@ def strip_duplicate_locations(time_position_power, eps=1e-10):
                 # This entry is at a new position - append this event
                 out.append(entry)
             else:
-                # This entry is as the same position as the one after it
+                # This entry is at the same position as the one after it
                 # If both entries are dwells, they can be combined
                 # Otherwise, combining entries will change the scan path itself
                 # To avoid this, slightly perturb the position rather than combining entries


### PR DESCRIPTION
Previously, the short dwells added to the start of each layer would be stripped from the scan path, as they have the same x,y,z position as the subsequent segment. The modification to `add_power_off_entry` slightly perturbs the x position of these entries to avoid being stripped.

The modification to `strip_duplicate_locations` ensures that only consecutive dwells are combined, as combining multiple scan segments or combining scan segments with dwells will modify the scan path itself (could remove dwells or change the beam velocity between events). This is again accomplished by slightly perturbing the x positions of events.